### PR TITLE
appinfo.json: Update permissions for Enhanced ACG

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -1,6 +1,6 @@
 {
     "id": "com.palm.app-museum2",
-    "version": "2.9.3",
+    "version": "2.9.4",
     "versionNote": "LuneOS fixes and enhancements",
     "lastModifiedTime": "2020-12-04T13:04:48-04:00",
     "vendor": "webOS Archive",
@@ -19,5 +19,5 @@
             "launchParam": { "common": { "sceneType": "search", "params": { "type": "query", "search": "#{searchTerms}" } } }
         }
     },
-    "requiredPermissions": ["applications.internal", "applications", "activities.manage", "devices", "settings", "settings.read", "services", "database", "database.internal", "filecache", "system", "networking", "networking.internal"]
+    "requiredPermissions": ["appmanager.management", "preferences.system"]
 }


### PR DESCRIPTION
With LuneOS migration to LG's new Enhanced ACG, new permissions are required for the app to work properly.

https://github.com/webOS-ports/luna-appmanager/blob/herrie/enhanced-acg-new/files/sysbus/luna-appmanager.api.json#L2 and https://github.com/webosose/luna-prefs/blob/master/files/sysbus/com.palm.preferences.api.json#L11

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>