### PR TITLE
Fix detection on newer LuneOS

### DIFF
--- a/app/details.js
+++ b/app/details.js
@@ -582,7 +582,7 @@ enyo.kind({
         if (window.location.hostname && window.location.hostname.indexOf(".media.cryptofs.apps") != -1) {   // Running on webOS
             this.$.serviceRequest.call({ id: "org.webosinternals.preware", params: { type: "install", file: app } });
             this.$.countDownloadRequest.setUrl(banneret.getPrefs("detailLocation") + "/countAppDownload.php?appid=" + myApp.id + "&source=webos");
-        } else if(window.location.href.indexOf("file:///media/cryptofs") != -1) { // Running on LuneOS
+        } else if(window.location.protocol === "file:" && window.location.pathname.indexOf("/media/cryptofs") != -1) { // Running on LuneOS
             this.$.serviceRequest.call({ id: "org.webosports.app.preware", params: { type: "install", file: app } });
             this.$.countDownloadRequest.setUrl(banneret.getPrefs("detailLocation") + "/countAppDownload.php?appid=" + myApp.id + "&source=luneos");
         } else {    // Running in a web browser


### PR DESCRIPTION
With last LuneOS update, the URL of the apps has changed and the "host" part is now filled with the string "`<appId>-webos`".

Therefore, the location href is now: "file://com.palm.app-museum2-webos/media/cryptofs/apps/usr/palm/applications/com.palm.app-museum2/index.html" and cannot be detected with the current code.

Add a more precise test against the protocol and pathname properties of window.location to be able to detect LuneOS correctly.